### PR TITLE
errors of replaying iframe records

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "@types/minimist": "^1.2.1",
     "@types/puppeteer": "^5.4.0",
     "minimist": "^1.2.5",
-    "puppeteer": "^5.4.1",
-    "rrweb-player": "^0.6.5",
+    "puppeteer": "^14.1.0",
+    "rrweb-player": "^0.7.4",
     "typescript": "^4.0.5"
   }
 }


### PR DESCRIPTION
ailed to execute 'appendChild' on 'Node': Nodes of type '#document' may not be inserted inside nodes of type '#document-fragment'.