### PR TITLE
解决rrvideo 用无头浏览器渲染页面时展示与真实录制的页面渲染不一致

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rrvideo",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "transform rrweb session into video",
   "main": "build/index.js",
   "bin": {
@@ -21,7 +21,7 @@
     "@types/puppeteer": "^5.4.0",
     "minimist": "^1.2.5",
     "puppeteer": "^5.4.1",
-    "rrweb-player": "^0.6.5",
+    "rrweb-player": "^1.0.0-alpha.4",
     "typescript": "^4.0.5"
   }
 }


### PR DESCRIPTION
验证了下，更新了rrweb-player 为最新的版本就好了，目前rrvideo内使用的rrweb-player还是旧仓库的npm，没有随着rrweb/rrweb-player里版本进行更新导致